### PR TITLE
relax pydantic version to accommodate ray[serve] 2.9.2

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.0.23
+
+- relax pydantic version to accommodate ray[serve] 2.9.2
+
 # 0.0.22
 
 - safe load json

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "lastmile_utils"
-version = "0.0.22"
+version = "0.0.23"
 authors = [
     { name="Jonathan Lessinger", email="jonathan@lastmileai.dev" },
 ]

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,7 +4,7 @@ flake8==6.1.0
 isort==5.12.0
 jsoncomment==0.4.2
 pandas==2.1.2
-pydantic==2.4.2
+pydantic>=2.4.2,<3
 pylint==3.0.2
 pyright==1.1.335
 pytest==7.4.3


### PR DESCRIPTION
relax pydantic version to accommodate ray[serve] 2.9.2

Test:

install from requirements, install ray[serve], see pydantic version (it does 2.6)
