### PR TITLE
[Proposal] Exception handling and library structure

### DIFF
--- a/python/examples/library_structure/my_library/api.py
+++ b/python/examples/library_structure/my_library/api.py
@@ -1,0 +1,34 @@
+from typing import Optional
+from lastmile_utils.lib.core.lm_result import (
+    EResult,
+    result_return_or_raise_for_apis_only,
+)
+
+from .lib import impl_outermost
+
+
+def example_api_function(key: str, default_int: Optional[int]) -> int:
+    """
+    This is an example LM API function.
+
+    It is deliberately extremely short and simple,
+    in the spirit of a header file.
+
+    It is a wrapper around the actual implementation,
+    in this case `impl_outermost()` which is imported from
+    our library.
+
+    Notice that impl_outermost() returns an EResult,
+    which is why we use the decorator here.
+
+    The decorator not only automatically unpacks the value
+    or raises an exception, but it also does some logging for us
+    and specific handling of different common Exception types.
+    """
+
+    @result_return_or_raise_for_apis_only
+    def impl_(key: str, default_int: Optional[int]) -> EResult[int]:
+        output = impl_outermost(key, default_int)
+        return output
+
+    return impl_(key, default_int)

--- a/python/examples/library_structure/my_library/lib.py
+++ b/python/examples/library_structure/my_library/lib.py
@@ -1,0 +1,126 @@
+from functools import partial
+import logging
+from textwrap import dedent
+from typing import Optional
+from result import Err, Ok
+from lastmile_utils.lib.core.lm_result import (
+    EResult,
+    make_err,
+    resultify_exceptions,
+)
+
+import lastmile_utils.lib.core.utils as utils
+from lastmile_utils.lib.core.utils import UserError
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format=utils.LOGGER_FMT)
+
+
+@resultify_exceptions
+def _mapping_lookup(key: str) -> str:
+    """This is the bottom of our call stack, and the possible source of
+    an Exception.
+
+    Specifically, we are calling into Python core library code
+    by doing the mapping lookup below.
+
+    Therefore, this is a good place to use the `resultify_exceptions` decorator.
+
+    The decorator catches any Exception and wraps it in a Result type (Err).
+    If we hit the return, it will be wrapped in an Ok.
+
+    The idea is to quarantine unchecked problems in as tight a space as possible.
+
+    If we hit an Exception, it will be caught immediately, and
+    throughout the rest of the call stack it will be statically checkable.
+
+    """
+    mapping = {
+        "good": "42",
+        "bad-value": "invalid-for-some-reason",
+    }
+
+    value = mapping[key]
+    return value
+
+
+def _look_up_value(key: str) -> EResult[str]:
+    """Just some helper function"""
+    if key == "bug":
+        # Deliberate example bug: exception raised.
+        # Unfortunately, there is no way to find these statically.
+        raise ValueError("bar")
+    else:
+
+        return _mapping_lookup(key)
+
+
+def _transform_key_step_1(key: str) -> EResult[str]:
+    """Just some helper function"""
+    if key == "bad-key":
+        return Err(UserError(f"Can't preprocess key {key}"))
+    else:
+        return Ok(key.strip())
+
+
+def _transform_key_step_2(key: str) -> str:
+    """Just some helper function"""
+    return key.lower()
+
+
+def _transform_value(value: str, default_int: Optional[int]) -> EResult[int]:
+    transformed = _transform_value_helper(value)
+
+    def _err_to_default_int(e: Exception) -> EResult[int]:
+        if default_int is None:
+            return Err(
+                UserError(
+                    dedent(
+                        f"""
+                        No default int provided, and failed to transform value 
+                        due to:
+                        Exception: {e}
+                        """
+                    )
+                )
+            )
+        else:
+            return Ok(default_int)
+
+    # Use this to recover from Err in certain cases.
+    return transformed.or_else(_err_to_default_int)
+
+
+def _transform_value_helper(value: str) -> EResult[int]:
+    if len(value) == len("invalid-for-some-reason"):
+        return make_err(ValueError("value is invalid"))
+    else:
+        return Ok(len(value))
+
+
+def impl_middle(key: str, default_int: Optional[int]) -> EResult[int]:
+    """Just some helper function"""
+    return (
+        _transform_key_step_1(key)
+        .map(_transform_key_step_2)
+        .and_then(_look_up_value)
+        .and_then(partial(_transform_value, default_int=default_int))
+    )
+
+
+def impl_outermost(key: str, default_int: Optional[int]) -> EResult[int]:
+    """Outermost implementation function. Calls down into a stack of
+    helper functions.
+
+    Notice that most of this code is statically checkable for exceptions.
+    Every function boundary in this file is wrapped in a Result type.
+    Since we have used the `resultify_exceptions` decorator at the lowest point,
+    we don't have to catch exceptions.
+
+    Just pay attention to pyright and handle all the Result types in
+    some statically safe way.
+    If pyright is happy, you are much less likely to get hit with a bug report.
+    """
+    value = impl_middle(key, default_int)
+
+    return value

--- a/python/examples/library_structure/user_app.py
+++ b/python/examples/library_structure/user_app.py
@@ -1,0 +1,41 @@
+import argparse
+from typing import Optional
+import my_library.api as my_library
+
+
+class UserAppDefinedException(Exception):
+    pass
+
+
+def use_library(key: str, default_int: Optional[int] = None):
+    print("Running example with key:", key)
+    return my_library.example_api_function(key, default_int)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--key",
+        required=True,
+        type=str,
+        choices=[
+            "good",
+            # uncaught exception raised
+            "bug",
+            # User error
+            "bad-key",
+            # Potentially Recoverable error
+            "bad-value",
+        ],
+    )
+    parser.add_argument("--default-int", type=int)
+    args = parser.parse_args()
+    try:
+        value = use_library(args.key, args.default_int)
+        print("Value:", value)
+    except Exception as e:
+        raise UserAppDefinedException() from e
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/lastmile_utils/lib/core/lm_result.py
+++ b/python/src/lastmile_utils/lib/core/lm_result.py
@@ -1,0 +1,156 @@
+import copy
+import inspect
+import logging
+import types
+from typing import Callable, Optional, ParamSpec, TypeVar
+import lastmile_utils.lib.core.utils as utils
+
+from result import Err, Ok, Result
+
+from lastmile_utils.lib.core.utils import InternalError
+
+T_ParamSpec = ParamSpec("T_ParamSpec")
+T_cov = TypeVar("T_cov", covariant=True)
+T_Exn = TypeVar("T_Exn", bound=Exception)
+EResult = Result[T_cov, Exception]
+
+logger = logging.getLogger(__name__)
+
+# TODO configure level
+logging.basicConfig(level=logging.INFO, format=utils.LOGGER_FMT)
+
+
+def resultify_exceptions(
+    f: Callable[T_ParamSpec, T_cov]
+) -> Callable[T_ParamSpec, EResult[T_cov]]:
+    """
+    Turn a callable that might raise an exception into a callable that
+    returns a Result type.
+    This also stores convenient traceback information.
+
+    Generally, you should use this when calling out across code boundaries
+    into 3rd party code (that can raise Exceptions).
+
+    That is, use this at the lowest possible level.
+
+    This can also be used for user-provided callbacks.
+
+    Output: a function that is the same as the input function,
+    but where the output / any Exception is wrapped in a EResult
+        (with lots of convenient traceback info).
+    """
+
+    def inner(
+        *args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs
+    ) -> EResult[T_cov]:
+        try:
+            return Ok(f(*args, **kwargs))
+        except Exception as e:
+            frame = inspect.currentframe()
+            e_new = copy.copy(e)
+            tb_to_here = _frame_to_tb(frame)
+            e_new.__traceback__ = tb_to_here
+            e_new.__cause__ = e
+            return Err(e_new)
+
+    return inner
+
+
+def make_err(e: Exception) -> EResult[T_cov]:
+    """
+    Use this as an alternative to the Err constructor for nicer
+    traceback info.
+    """
+
+    @resultify_exceptions
+    def _inner() -> T_cov:
+        raise e
+
+    return _inner()
+
+
+def result_return_or_raise_for_apis_only(
+    fn: Callable[T_ParamSpec, EResult[T_cov]]
+) -> Callable[T_ParamSpec, T_cov]:
+    """
+    PLEASE ONLY USE THIS AT THE TOP LEVEL OF YOUR APPLICATION,
+    AT USER INTERFACES.
+
+    **Description**
+
+    The purpose of this is to provide users with the standard
+    Python exception outcome, namely, raising an exception.
+
+    You should use it at LM API boundaries and probably nowhere else.
+
+    Because this function raises, it should be used judiciously.
+    It is intentionally named to deter usage, or at least to provide
+    something to grep for during debugging.
+
+
+
+    **Input / Output**
+
+    It essentially inverts `resultify_exceptions()`. That is,
+    it takes a function returning a EResult, and outputs an analogous function
+    that returns the inside value type, or raises an exception.
+
+    It also does some convenient logging and handling of
+    different types of exceptions.
+
+
+    See examples/library_structure/my_library/api.py for an example.
+    """
+
+    def return_or_raise_(
+        *args: T_ParamSpec.args, **kwargs: T_ParamSpec.kwargs
+    ) -> T_cov:
+        try:
+            result = fn(*args, **kwargs)
+        except Exception as e:
+            message = f"""
+            Unexpected error!
+            An Exception was caught inside 
+            result_return_or_raise_for_apis_only().
+            
+            This means there is probably a missing application of the 
+            resultify_exceptions() decorator. Please see the stack trace.
+
+            Please file a bug report...
+            """
+            logger.critical(message)
+            raise InternalError(message) from e
+
+        match result:
+            case Ok(value):
+                return value
+            case Err(e):
+                logger.error(f"Exception: {e}")
+                raise e
+
+    return return_or_raise_
+
+
+def _frame_to_tb(
+    frame: Optional[types.FrameType],
+) -> Optional[types.TracebackType]:
+    """This stuff really brings me back to freshman CS"""
+    return _frame_to_tb_rec(frame, None)
+
+
+def _frame_to_tb_rec(
+    frame: Optional[types.FrameType], acc: Optional[types.TracebackType]
+) -> Optional[types.TracebackType]:
+    """
+    This one especially brings up nostalgia for
+    [CS19](https://cs.brown.edu/courses/cs019/).
+
+    I'm almost tempted to write this in Scheme...
+    """
+    if frame is None:
+        return acc
+    else:
+        return _frame_to_tb_rec(
+            frame.f_back,
+            types.TracebackType(acc, frame, frame.f_lasti, frame.f_lineno),
+        )

--- a/python/src/lastmile_utils/lib/core/utils.py
+++ b/python/src/lastmile_utils/lib/core/utils.py
@@ -496,3 +496,23 @@ async def run_thunk_safe(
 @exception_to_err_with_traceback
 def safe_load_json(json_str: str) -> JSONObject:
     return json.loads(json_str)
+
+
+class InternalError(Exception):
+    """
+    Represents unexpected error originating from a LM library.
+
+    (Expected errors / Exceptions should be represented as EResult.)
+    """
+
+    def __init__(self, *args: object):
+        super().__init__(*args)
+
+
+class UserError(Exception):
+    """
+    Represents an exception that is (demonstrably) the result of
+    the user violating one of our API contracts.
+    """
+
+    pass


### PR DESCRIPTION
[Proposal] Exception handling and library structure

Add some new types, a small layer on top of Result, and an example of how to structure a library.

# Main ideas

1.
UserError vs. InternalError

2.
API (thin conversion layer) vs. implementation (bulk of our code)


2. Convenient Result type for internal exceptions
`EResult = Result[..., Exception]`


Do this as low as possible
```
@resultify_exceptions
def ...
```


Can use this instead of just `Err()` for better stack traces

`make_err(my_exception)`


3. Convert back to Exception for APIs

```
@careful_do_you_really_want_to_call_me_return_or_raise
def ...
```


## Example Structure

User code
-> LM API (return normal value or raise)
-> LM impl (use Result internally)
-> Wrap any 3rd party calls in a Result


The example has:
- api.py, an example LM API (in the spirit of a header file)
  - This uses the Result layer to unwrap back into nice exceptions
- lib.py, the implementation file, uses Result operations internally


## Distinguish between UserError and InternalError

Full stack traces for InternalError for bug reports, else just the part relevant to caller.

By definition, InternalError is always a bug - it's always unexpected.
If an exception is not a user error, we should either turn it into one or recover somehow.


# Try running the example user app

- Many potential bugs involving unhandled exceptional cases are caught by pyright.
- UserErrors are shown as such.
- One class of bugs (raised exception) is impossible to detect statically,
but full stack trace is shown



```
python python/examples/library_structure/user_app.py --key=good

Running example with key: good
Value: 2

```

```
# Intentional bug example
python/examples/library_structure/user_app.py --key=bug

lastmile_utils.lib.core.utils.InternalError:
            Unexpected error!
            An Exception was caught inside
            careful_do_you_really_want_to_call_me_return_or_raise().

            This means there is probably a missing application of the
            resultify_exceptions() decorator. Please see the stack trace.

            Please file a bug report...

```

```
# User error

python python/examples/library_structure/user_app.py --key=bad-key


lastmile_utils.lib.core.utils.UserError: Can't preprocess key bad-key
```


```
# Recoverable internal exception

python python/examples/library_structure/user_app.py --key=bad-value --default-int=5
Running example with key: bad-value
Value: 5


```
